### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report about incorrect behavior
+title: "[Bug] "
+labels: bug
+assignees: ''
+
+---
+
+### Summary of the issue
+A clear and concise description of what the bug is.
+
+### Steps to Reproduce
+Specific steps to reproduce the issue:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+
+### Actual behavior
+What is currently happening that shouldn't after the steps above
+
+### Expected behavior
+A clear and concise description of what should happen after the steps.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Links to impacted areas
+If applicable, provide specific URLs/direction to pages or other areas that are affected by the bug
+
+### Workarounds
+What other options there are, if any, for the user to get past the issue (e.g. navigating to a page a different way if there is a broken link)
+
+### Environment/Context
+Environment variables, browser, OS, or other potentially relevant technical details about the situation where it was encountered.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for the DMP Tool [WIP]
+title: "[Request] "
+labels: ''
+assignees: ''
+
+---
+
+### Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### What area of the tool is it for?
+E.g. creating templates, adding customization, writing plans, publishing plans
+
+### Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/task-ticket.md
+++ b/.github/ISSUE_TEMPLATE/task-ticket.md
@@ -1,0 +1,28 @@
+---
+name: Task ticket
+about: Define new development work to be completed
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Summary
+Short summary of the task.
+
+### Context
+Why it's needed / background context
+
+### Links to impacted areas
+Provide specific URLs to pages or other areas that would be affected
+
+### Design Information
+Provide links to wireframes, URLs of current tool pages to copy, screenshots, mock-ups, or a detailed description of what it should look like
+
+### Acceptance criteria
+Add more specific details here about what to implement and how the end behavior should work
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+### Relevant Technical Decisions
+As we make decisions as a group on technical or implementation details, add notes here.  This just should be updated over time and have the latest information


### PR DESCRIPTION
Added 3 Issue Templates.  Two were already reviewed and approved by the team.  The third Feature Request template is mostly a GitHub standard that we would have ready when we go live more for external users.